### PR TITLE
Exit code of zero from `ack --man`

### DIFF
--- a/ack
+++ b/ack
@@ -1362,7 +1362,13 @@ sub get_command_line_options {
         'version'   => sub { print_version_statement(); exit 1; },
         'help|?:s'  => sub { shift; show_help(@_); exit; },
         'help-types'=> sub { show_help_types(); exit; },
-        'man'       => sub { require Pod::Usage; Pod::Usage::pod2usage({-verbose => 2}); exit; },
+        'man'       => sub {
+            require Pod::Usage;
+            Pod::Usage::pod2usage({
+                -verbose => 2,
+                -exitval => 0,
+            });
+        },
 
         'type=s'    => sub {
             # Whatever --type=xxx they specify, set it manually in the hash


### PR DESCRIPTION
Hi,

First off, thank you for ack.  It's really a great tool.

I noticed recently that ack has a non-zero exit code when invoked with the --man option, and I was wondering if this was the intended behavior.

There is an "exit;" immediately after the call to pod2usage, but it seems that pod2usage exits internally, and doesn't return control to the caller.

This small patch just causes `ack --man` to indicate success when complete.

Thanks,

Bo
