### PR TITLE
Re: ack may ignore files with multi-byte encodings

### DIFF
--- a/Basic.pm
+++ b/Basic.pm
@@ -123,6 +123,7 @@ sub needs_line_scan {
         App::Ack::warn( "$self->{filename}: $!" );
         return 1;
     }
+    $rc = sysseek($self->{fh}, 0, 1); # position in bytes
     return 0 unless $rc && ( $rc == $size );
 
     my $regex = $opt->{regex};

--- a/ack
+++ b/ack
@@ -2681,6 +2681,7 @@ sub needs_line_scan {
         App::Ack::warn( "$self->{filename}: $!" );
         return 1;
     }
+    $rc = sysseek($self->{fh}, 0, 1); # position in bytes
     return 0 unless $rc && ( $rc == $size );
 
     my $regex = $opt->{regex};


### PR DESCRIPTION
I think my one-line change to Basic.pm solves the problem I pointed out.  It does for me (obviously) and doesn't hurt the existing tests.

I haven't been able to make up a specific test for the rejection of multibyte-encoded files with the given testing framework.  There seem to be additional encoding problems that make it hard to use run_ack() for that.  So I'm just sending the fix.

Anno
