### PR TITLE
Add relative paths to --ignore-dir instead of just allowing directory names.

### DIFF
--- a/Ack.pm
+++ b/Ack.pm
@@ -456,7 +456,7 @@ to ignore.
 =cut
 
 sub ignoredir_filter {
-    return !exists $ignore_dirs{$_};
+    return !exists $ignore_dirs{$_} && !exists $ignore_dirs{$File::Next::dir};
 }
 
 =head2 remove_dir_sep( $path )

--- a/t/ack-ignore-dir.t
+++ b/t/ack-ignore-dir.t
@@ -3,7 +3,7 @@
 use warnings;
 use strict;
 
-use Test::More tests => 24;
+use Test::More tests => 26;
 use File::Spec;
 
 use lib 't';
@@ -134,6 +134,15 @@ DASH_U_BEATS_THE_PANTS_OFF_IGNORE_DIR_ANY_DAY_OF_THE_WEEK: {
     set_up_assertion_that_these_options_will_ignore_those_directories(
         [ '-u', '--ignore-dir=subdir', ],
         [                              ],
+    );
+    sets_match( \@results, \@expected, $test_description );
+}
+
+DASH_IGNORE_DIR_IGNORES_RELATIVE_PATHS: {
+    set_up_assertion_that_these_options_will_ignore_those_directories(
+        [ '--ignore-dir=t/swamp/groceries/another_subdir', ],
+        [ @std_ignore, 'another_subdir',                   ],
+        'ignore relative paths instead of just directory names',
     );
     sets_match( \@results, \@expected, $test_description );
 }


### PR DESCRIPTION
Here is an example of what you can do with the tweak to --ignore-dir:

If you do: `ack -f --ignore-dir=t/swamp/groceries/another_subdir` with this directory structure:
    t/swamp/groceries/fruit
    t/swamp/groceries/junk
    t/swamp/groceries/another_subdir/fruit
    t/swamp/groceries/another_subdir/junk
    t/swamp/groceries/subdir/fruit
    t/swamp/groceries/subdir/junk

You will get this list:
    t/swamp/groceries/fruit
    t/swamp/groceries/junk
    t/swamp/groceries/subdir/fruit
    t/swamp/groceries/subdir/junk
