### PR TITLE
Ignore *.min.js files

### DIFF
--- a/Ack.pm
+++ b/Ack.pm
@@ -558,6 +558,7 @@ Recognized files:
   /#.+#$/         - Emacs swap files
   /[._].*\.swp$/  - Vi(m) swap files
   /core\.\d+$/    - core dumps
+  /[.]min\.js$/   - Minified javascript files
 
 Note that I<$filename> must be just a file, not a full path.
 
@@ -572,6 +573,7 @@ sub is_searchable {
     return if $filename =~ m{^#.*#$}o;
     return if $filename =~ m{^core\.\d+$}o;
     return if $filename =~ m{[._].*\.swp$}o;
+    return if $filename =~ /[.]min\.js$/;
 
     return 1;
 }
@@ -810,10 +812,11 @@ File inclusion/exclusion:
     $ignore_dirs
 
   Files not checked for type:
-    /~\$/           - Unix backup files
-    /#.+#\$/        - Emacs swap files
+    /~\$/            - Unix backup files
+    /#.+#\$/         - Emacs swap files
     /[._].*\\.swp\$/ - Vi(m) swap files
-    /core\\.\\d+\$/   - core dumps
+    /core\\.\\d+\$/  - core dumps
+    /[.]min\\.js\$/  - Minified javascript files
 
 Miscellaneous:
   --noenv               Ignore environment variables and ~/.ackrc

--- a/ack
+++ b/ack
@@ -1642,6 +1642,7 @@ sub is_searchable {
     return if $filename =~ m{^#.*#$}o;
     return if $filename =~ m{^core\.\d+$}o;
     return if $filename =~ m{[._].*\.swp$}o;
+    return if $filename =~ /[.]min\.js$/;
 
     return 1;
 }
@@ -1845,10 +1846,11 @@ File inclusion/exclusion:
     $ignore_dirs
 
   Files not checked for type:
-    /~\$/           - Unix backup files
-    /#.+#\$/        - Emacs swap files
+    /~\$/            - Unix backup files
+    /#.+#\$/         - Emacs swap files
     /[._].*\\.swp\$/ - Vi(m) swap files
-    /core\\.\\d+\$/   - core dumps
+    /core\\.\\d+\$/  - core dumps
+    /[.]min\\.js\$/  - Minified javascript files
 
 Miscellaneous:
   --noenv               Ignore environment variables and ~/.ackrc

--- a/ack-help-dirs.txt
+++ b/ack-help-dirs.txt
@@ -110,10 +110,11 @@ File inclusion/exclusion:
     ~.dot, .git, .hg, _MTN, ~.nib, .pc, ~.plst, RCS, SCCS, _sgbak and .svn
 
   Files not checked for type:
-    /~$/           - Unix backup files
-    /#.+#$/        - Emacs swap files
+    /~$/            - Unix backup files
+    /#.+#$/         - Emacs swap files
     /[._].*\.swp$/ - Vi(m) swap files
-    /core\.\d+$/   - core dumps
+    /core\.\d+$/  - core dumps
+    /[.]min\.js$/  - Minified javascript files
 
 Miscellaneous:
   --noenv               Ignore environment variables and ~/.ackrc

--- a/ack-help.txt
+++ b/ack-help.txt
@@ -110,10 +110,11 @@ File inclusion/exclusion:
     ~.dot, .git, .hg, _MTN, ~.nib, .pc, ~.plst, RCS, SCCS, _sgbak and .svn
 
   Files not checked for type:
-    /~$/           - Unix backup files
-    /#.+#$/        - Emacs swap files
+    /~$/            - Unix backup files
+    /#.+#$/         - Emacs swap files
     /[._].*\.swp$/ - Vi(m) swap files
-    /core\.\d+$/   - core dumps
+    /core\.\d+$/  - core dumps
+    /[.]min\.js$/  - Minified javascript files
 
 Miscellaneous:
   --noenv               Ignore environment variables and ~/.ackrc


### PR DESCRIPTION
The commit adds *.min.js files to the ignore list.
These are usually minified javascript, which makes no sense to grep, since it's usually generated from another file in the same repository, and the text has no newlines, so it's a constant annoyance.
