### PR TITLE
Small improvements to shebang type detection

### DIFF
--- a/Ack.pm
+++ b/Ack.pm
@@ -538,7 +538,7 @@ sub filetypes {
     close $fh;
 
     if ( $header =~ /^#!/ ) {
-        return ($1,TEXT)       if $header =~ /\b(ruby|p(?:erl|hp|ython))\b/;
+        return ($1,TEXT)       if $header =~ /\b(ruby|lua|p(?:erl|hp|ython))\b/;
         return ('shell',TEXT)  if $header =~ /\b(?:ba|t?c|k|z)?sh\b/;
     }
     else {

--- a/Ack.pm
+++ b/Ack.pm
@@ -538,7 +538,7 @@ sub filetypes {
     close $fh;
 
     if ( $header =~ /^#!/ ) {
-        return ($1,TEXT)       if $header =~ /\b(ruby|lua|p(?:erl|hp|ython))\b/;
+        return ($1,TEXT)       if $header =~ /\b(ruby|lua|p(?:erl|hp|ython))\d*\b/;
         return ('shell',TEXT)  if $header =~ /\b(?:ba|t?c|k|z)?sh\b/;
     }
     else {


### PR DESCRIPTION
These 2 commits fix the regex for shebang type detection to 1) support 'lua'  2) support version numbers at the end of the interpreter name, e.g. python26, ruby1.9, lua5.1

Regards,
Matthew
