### PR TITLE
Add Puppet (.pp) files as a type

### DIFF
--- a/Ack.pm
+++ b/Ack.pm
@@ -105,6 +105,7 @@ BEGIN {
         perl        => [qw( pl pm pod t )],
         php         => [qw( php phpt php3 php4 php5 phtml)],
         plone       => [qw( pt cpt metadata cpy py )],
+	puppet      => [qw( pp )],
         python      => [qw( py )],
         rake        => q{Rakefiles},
         ruby        => [qw( rb rhtml rjs rxml erb rake spec )],

--- a/ack-help-types.txt
+++ b/ack-help-types.txt
@@ -40,6 +40,7 @@ Note that some extensions may appear in multiple types.  For example,
     --[no]perl         .pl .pm .pod .t
     --[no]php          .php .phpt .php3 .php4 .php5 .phtml
     --[no]plone        .pt .cpt .metadata .cpy .py
+    --[no]puppet       .pp
     --[no]python       .py
     --[no]rake         Rakefiles
     --[no]ruby         .rb .rhtml .rjs .rxml .erb .rake .spec

--- a/btg/ack-help-types.txt
+++ b/btg/ack-help-types.txt
@@ -40,6 +40,7 @@ Note that some extensions may appear in multiple types.  For example,
     --[no]perl         .pl .pm .pod .t
     --[no]php          .php .phpt .php3 .php4 .php5 .phtml
     --[no]plone        .pt .cpt .metadata .cpy .py
+    --[no]puppet       .pp
     --[no]python       .py
     --[no]rake         Rakefiles
     --[no]ruby         .rb .rhtml .rjs .rxml .erb .rake .spec


### PR DESCRIPTION
Two very small commits to add Puppet manifests (.pp files) as a type for ack.

Thanks for your consideration.

-Andy
