### PR TITLE
Point $ENV{ACKRC} to an empty file for testing

### DIFF
--- a/t/Util.pm
+++ b/t/Util.pm
@@ -3,7 +3,7 @@ use File::Next ();
 use App::Ack ();
 
 sub prep_environment {
-    delete @ENV{qw( ACK_OPTIONS ACKRC ACK_PAGER )};
+    delete @ENV{qw( ACK_OPTIONS ACK_PAGER )};
     $ENV{ACKRC} = 't/ackrc';
 }
 

--- a/t/Util.pm
+++ b/t/Util.pm
@@ -4,6 +4,7 @@ use App::Ack ();
 
 sub prep_environment {
     delete @ENV{qw( ACK_OPTIONS ACKRC ACK_PAGER )};
+    $ENV{ACKRC} = 't/ackrc';
 }
 
 # capture stderr output into this file

--- a/t/ackrc
+++ b/t/ackrc
@@ -1,0 +1,1 @@
+# empty ackrc file for testing


### PR DESCRIPTION
t/ack-env.t fails on my local machine because I have
"--columns" in my ~/.ackrc file.

Instead of deleting $ENV{ACKRC} point it to an empty file
in the t/ dir to ensure there are no unexpected options set.
