### PR TITLE
Add nqp and pm6 to the list of Perl-related file extensions

### DIFF
--- a/Ack.pm
+++ b/Ack.pm
@@ -103,7 +103,7 @@ BEGIN {
         objcpp      => [qw( mm h )],
         ocaml       => [qw( ml mli )],
         parrot      => [qw( pir pasm pmc ops pod pg tg )],
-        perl        => [qw( pl pm pod t )],
+        perl        => [qw( nqp pl pm6 pm pod t )],
         php         => [qw( php phpt php3 php4 php5 phtml)],
         plone       => [qw( pt cpt metadata cpy py )],
         python      => [qw( py )],


### PR DESCRIPTION
I very often find myself searching for things that end in .nqp and I have seen quite a few Perl 6 modules that use the .pm6 extension. Are there other changes that need to be made to Ack to support these extensions?
