### PR TITLE
Fixed the *other* link to ack-standalone on ack.googlecode.com

### DIFF
--- a/btg/index.php
+++ b/btg/index.php
@@ -181,7 +181,7 @@ _   /|
         <ol>
             <li>It's <b>blazingly fast</b> because it only searches the stuff you want searched.</li>
             <li>ack is pure Perl, so it <b>runs on Windows</b> just fine. It has <b>no dependencies</b> other than Perl 5.</li>
-            <li>The <a href="http://ack.googlecode.com/svn/tags/latest/ack">standalone
+            <li>The <a href="http://betterthangrep.com/ack-standalone">standalone
                 version</a> uses no non-standard modules, so you can put it in your
             <tt>~/bin</tt> without fear.</li>
             <li>


### PR DESCRIPTION
Step 3 of the Top 10 Reasons to use Ack still has a broken link to ack.googlecode.com.  This should fix it.
