### PR TITLE
Add File::Next prerequisite section to README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -5,6 +5,11 @@ ack is *not* intended to be a general-purpose replacement for grep.
 ack is for searching source code of defined file types.  For searching
 other files, you may want to stick with grep.
 
+# DEPENDENCIES
+
+    File::Next
+        https://github.com/petdance/file-next
+
 # INSTALLATION
 
 To install this module, run the following commands:


### PR DESCRIPTION
Despite not having this listed as a prerequisite, it was neccessary that I  install File::Next before successfully installing ack on OS X 10.7.

I have listed that requirement in the README.markdown
