### PR TITLE
Fix GitHub URLs: http => https

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -42,7 +42,7 @@ if ( $ExtUtils::MakeMaker::VERSION ge '6.46' ) {
     $parms{META_MERGE} = {
         resources => {
             homepage    => 'http://betterthangrep.com/',
-            bugtracker  => 'http://github.com/petdance/ack',
+            bugtracker  => 'https://github.com/petdance/ack',
             license     => 'http://www.opensource.org/licenses/artistic-license-2.0.php',
             repository  => 'git://github.com/petdance/ack.git',
         }

--- a/ack
+++ b/ack
@@ -4,7 +4,7 @@
 # Please DO NOT EDIT or send patches for it.
 #
 # Please take a look at the source from
-# http://github.com/petdance/ack
+# https://github.com/petdance/ack
 # and submit patches against the individual files
 # that build ack.
 #
@@ -856,7 +856,7 @@ Andy Lester, C<< <andy at petdance.com> >>
 =head1 BUGS
 
 Please report any bugs or feature requests to the issues list at
-Github: L<http://github.com/petdance/ack/issues>
+Github: L<https://github.com/petdance/ack/issues>
 
 =head1 ENHANCEMENTS
 
@@ -866,7 +866,7 @@ will not consider a request without it first getting seen by other
 ack users.  This includes requests for new filetypes.
 
 There is a list of enhancements I want to make to F<ack> in the ack
-issues list at Github: L<http://github.com/petdance/ack/issues>
+issues list at Github: L<https://github.com/petdance/ack/issues>
 
 Patches are always welcome, but patches with tests get the most
 attention.
@@ -883,7 +883,7 @@ L<http://betterthangrep.com/>
 
 =item * The ack issues list at Github
 
-L<http://github.com/petdance/ack/issues>
+L<https://github.com/petdance/ack/issues>
 
 =item * AnnoCPAN: Annotated CPAN documentation
 
@@ -899,7 +899,7 @@ L<http://search.cpan.org/dist/ack>
 
 =item * Git source repository
 
-L<http://github.com/petdance/ack>
+L<https://github.com/petdance/ack>
 
 =back
 

--- a/ack-base
+++ b/ack-base
@@ -848,7 +848,7 @@ Andy Lester, C<< <andy at petdance.com> >>
 =head1 BUGS
 
 Please report any bugs or feature requests to the issues list at
-Github: L<http://github.com/petdance/ack/issues>
+Github: L<https://github.com/petdance/ack/issues>
 
 =head1 ENHANCEMENTS
 
@@ -858,7 +858,7 @@ will not consider a request without it first getting seen by other
 ack users.  This includes requests for new filetypes.
 
 There is a list of enhancements I want to make to F<ack> in the ack
-issues list at Github: L<http://github.com/petdance/ack/issues>
+issues list at Github: L<https://github.com/petdance/ack/issues>
 
 Patches are always welcome, but patches with tests get the most
 attention.
@@ -875,7 +875,7 @@ L<http://betterthangrep.com/>
 
 =item * The ack issues list at Github
 
-L<http://github.com/petdance/ack/issues>
+L<https://github.com/petdance/ack/issues>
 
 =item * AnnoCPAN: Annotated CPAN documentation
 
@@ -891,7 +891,7 @@ L<http://search.cpan.org/dist/ack>
 
 =item * Git source repository
 
-L<http://github.com/petdance/ack>
+L<https://github.com/petdance/ack>
 
 =back
 

--- a/btg/ack-standalone
+++ b/btg/ack-standalone
@@ -4,7 +4,7 @@
 # Please DO NOT EDIT or send patches for it.
 #
 # Please take a look at the source from
-# http://github.com/petdance/ack
+# https://github.com/petdance/ack
 # and submit patches against the individual files
 # that build ack.
 #
@@ -856,7 +856,7 @@ Andy Lester, C<< <andy at petdance.com> >>
 =head1 BUGS
 
 Please report any bugs or feature requests to the issues list at
-Github: L<http://github.com/petdance/ack/issues>
+Github: L<https://github.com/petdance/ack/issues>
 
 =head1 ENHANCEMENTS
 
@@ -866,7 +866,7 @@ will not consider a request without it first getting seen by other
 ack users.  This includes requests for new filetypes.
 
 There is a list of enhancements I want to make to F<ack> in the ack
-issues list at Github: L<http://github.com/petdance/ack/issues>
+issues list at Github: L<https://github.com/petdance/ack/issues>
 
 Patches are always welcome, but patches with tests get the most
 attention.
@@ -883,7 +883,7 @@ L<http://betterthangrep.com/>
 
 =item * The ack issues list at Github
 
-L<http://github.com/petdance/ack/issues>
+L<https://github.com/petdance/ack/issues>
 
 =item * AnnoCPAN: Annotated CPAN documentation
 
@@ -899,7 +899,7 @@ L<http://search.cpan.org/dist/ack>
 
 =item * Git source repository
 
-L<http://github.com/petdance/ack>
+L<https://github.com/petdance/ack>
 
 =back
 

--- a/btg/index.php
+++ b/btg/index.php
@@ -94,7 +94,7 @@ _   /|
             the super-speedy "ack" tool to search your code
             FAST. It gives you beautiful, clickable results just
             as fast as "ack" can find them. Check it out at:
-            <a href="http://github.com/protocool/ackmate">http://github.com/protocool/ackmate</a>
+            <a href="https://github.com/protocool/ackmate">https://github.com/protocool/ackmate</a>
         </blockquote>
 
         <h2>Testimonials about ack</h2>

--- a/squash
+++ b/squash
@@ -13,7 +13,7 @@ my $NO_EDIT_COMMENT = <<'EOCOMMENT';
 # Please DO NOT EDIT or send patches for it.
 #
 # Please take a look at the source from
-# http://github.com/petdance/ack
+# https://github.com/petdance/ack
 # and submit patches against the individual files
 # that build ack.
 #


### PR DESCRIPTION
GitHub now uses always https.
This patch fixes all the GitHub URLs in POD, comments and META.

Thanks for ack!
