### PR TITLE
Support `--[no-]recur` flags

### DIFF
--- a/Ack.pm
+++ b/Ack.pm
@@ -233,7 +233,7 @@ sub get_command_line_options {
         'L|files-without-matches' => sub { $opt{l} = $opt{v} = 1 },
         'm|max-count=i'         => \$opt{m},
         'match=s'               => \$opt{regex},
-        'n|no-recurse'          => \$opt{n},
+        'n|no-recur|no-recurse' => \$opt{n},
         o                       => sub { $opt{output} = '$&' },
         'output=s'              => \$opt{output},
         'pager=s'               => \$opt{pager},
@@ -241,7 +241,7 @@ sub get_command_line_options {
         'passthru'              => \$opt{passthru},
         'print0'                => \$opt{print0},
         'Q|literal'             => \$opt{Q},
-        'r|R|recurse'           => sub { $opt{n} = 0 },
+        'r|R|recur|recurse'     => sub { $opt{n} = 0 },
         'show-types'            => \$opt{show_types},
         'smart-case!'           => \$opt{smart_case},
         'sort-files'            => \$opt{sort_files},
@@ -789,8 +789,10 @@ File inclusion/exclusion:
                         Ignores CVS, .svn and other ignored directories
   -u, --unrestricted    All files and directories searched
   --[no]ignore-dir=name Add/Remove directory from the list of ignored dirs
-  -r, -R, --recurse     Recurse into subdirectories (ack's default behavior)
-  -n, --no-recurse      No descending into subdirectories
+  -r, -R, --recur       Recur into subdirectories (ack's default behavior)
+  -r, -R, --recurse     Same as --recur
+  -n, --no-recur        No descending into subdirectories
+  -n, --no-recurse      Same as --no-recur
   -G REGEX              Only search files that match REGEX
 
   --perl                Include only Perl files.

--- a/ack
+++ b/ack
@@ -361,7 +361,7 @@ Stop reading a file after I<NUM> matches.
 
 Print this manual page.
 
-=item B<-n>, B<--no-recurse>
+=item B<-n>, B<--no-recur>
 
 No descending into subdirectories.
 
@@ -408,10 +408,10 @@ Quote all metacharacters in PATTERN, it is treated as a literal.
 This applies only to the PATTERN, not to the regexes given for the B<-g>
 and B<-G> options.
 
-=item B<-r>, B<-R>, B<--recurse>
+=item B<-r>, B<-R>, B<--recur>
 
-Recurse into sub-directories. This is the default and just here for
-compatibility with grep. You can also use it for turning B<--no-recurse> off.
+Recur into sub-directories. This is the default and just here for
+compatibility with grep. You can also use it for turning B<--no-recur> off.
 
 =item B<--smart-case>, B<--no-smart-case>
 
@@ -1356,7 +1356,7 @@ sub get_command_line_options {
         'L|files-without-matches' => sub { $opt{l} = $opt{v} = 1 },
         'm|max-count=i'         => \$opt{m},
         'match=s'               => \$opt{regex},
-        'n|no-recurse'          => \$opt{n},
+        'n|no-recur|no-recurse' => \$opt{n},
         o                       => sub { $opt{output} = '$&' },
         'output=s'              => \$opt{output},
         'pager=s'               => \$opt{pager},
@@ -1364,7 +1364,7 @@ sub get_command_line_options {
         'passthru'              => \$opt{passthru},
         'print0'                => \$opt{print0},
         'Q|literal'             => \$opt{Q},
-        'r|R|recurse'           => sub { $opt{n} = 0 },
+        'r|R|recur|recurse'     => sub { $opt{n} = 0 },
         'show-types'            => \$opt{show_types},
         'smart-case!'           => \$opt{smart_case},
         'sort-files'            => \$opt{sort_files},
@@ -1824,8 +1824,10 @@ File inclusion/exclusion:
                         Ignores CVS, .svn and other ignored directories
   -u, --unrestricted    All files and directories searched
   --[no]ignore-dir=name Add/Remove directory from the list of ignored dirs
-  -r, -R, --recurse     Recurse into subdirectories (ack's default behavior)
-  -n, --no-recurse      No descending into subdirectories
+  -r, -R, --recur       Recur into subdirectories (ack's default behavior)
+  -n, --no-recur        No descending into subdirectories
+  --recurse             Same as --recur
+  --no-recurse          Same as --no-recur
   -G REGEX              Only search files that match REGEX
 
   --perl                Include only Perl files.

--- a/ack-base
+++ b/ack-base
@@ -353,7 +353,7 @@ Stop reading a file after I<NUM> matches.
 
 Print this manual page.
 
-=item B<-n>, B<--no-recurse>
+=item B<-n>, B<--no-recur>
 
 No descending into subdirectories.
 
@@ -400,10 +400,10 @@ Quote all metacharacters in PATTERN, it is treated as a literal.
 This applies only to the PATTERN, not to the regexes given for the B<-g>
 and B<-G> options.
 
-=item B<-r>, B<-R>, B<--recurse>
+=item B<-r>, B<-R>, B<--recur>
 
-Recurse into sub-directories. This is the default and just here for
-compatibility with grep. You can also use it for turning B<--no-recurse> off.
+Recur into sub-directories. This is the default and just here for
+compatibility with grep. You can also use it for turning B<--no-recur> off.
 
 =item B<--smart-case>, B<--no-smart-case>
 

--- a/ack-help-dirs.txt
+++ b/ack-help-dirs.txt
@@ -85,8 +85,10 @@ File inclusion/exclusion:
                         Ignores CVS, .svn and other ignored directories
   -u, --unrestricted    All files and directories searched
   --[no]ignore-dir=name Add/Remove directory from the list of ignored dirs
-  -r, -R, --recurse     Recurse into subdirectories (ack's default behavior)
-  -n, --no-recurse      No descending into subdirectories
+  -r, -R, --recur       Recur into subdirectories (ack's default behavior)
+  -n, --no-recur        No descending into subdirectories
+  -r, -R, --recurse     Same as --recur
+  -n, --no-recurse      Same as --no-recur
   -G REGEX              Only search files that match REGEX
 
   --perl                Include only Perl files.

--- a/ack-help.txt
+++ b/ack-help.txt
@@ -85,8 +85,10 @@ File inclusion/exclusion:
                         Ignores CVS, .svn and other ignored directories
   -u, --unrestricted    All files and directories searched
   --[no]ignore-dir=name Add/Remove directory from the list of ignored dirs
-  -r, -R, --recurse     Recurse into subdirectories (ack's default behavior)
-  -n, --no-recurse      No descending into subdirectories
+  -r, -R, --recur       Recur into subdirectories (ack's default behavior)
+  -n, --no-recur        No descending into subdirectories
+  -r, -R, --recurse     Same as --recur
+  -n, --no-recurse      Same as --no-recur
   -G REGEX              Only search files that match REGEX
 
   --perl                Include only Perl files.

--- a/btg/ack-help.txt
+++ b/btg/ack-help.txt
@@ -85,8 +85,10 @@ File inclusion/exclusion:
                         Ignores CVS, .svn and other ignored directories
   -u, --unrestricted    All files and directories searched
   --[no]ignore-dir=name Add/Remove directory from the list of ignored dirs
-  -r, -R, --recurse     Recurse into subdirectories (ack's default behavior)
-  -n, --no-recurse      No descending into subdirectories
+  -r, -R, --recur       Recur into subdirectories (ack's default behavior)
+  -n, --no-recur        No descending into subdirectories
+  -r, -R, --recurse     Same as --recur
+  -n, --no-recurse      Same as --no-recur
   -G REGEX              Only search files that match REGEX
 
   --perl                Include only Perl files.

--- a/btg/ack-standalone
+++ b/btg/ack-standalone
@@ -361,7 +361,7 @@ Stop reading a file after I<NUM> matches.
 
 Print this manual page.
 
-=item B<-n>, B<--no-recurse>
+=item B<-n>, B<--no-recur>
 
 No descending into subdirectories.
 
@@ -408,10 +408,10 @@ Quote all metacharacters in PATTERN, it is treated as a literal.
 This applies only to the PATTERN, not to the regexes given for the B<-g>
 and B<-G> options.
 
-=item B<-r>, B<-R>, B<--recurse>
+=item B<-r>, B<-R>, B<--recur>
 
-Recurse into sub-directories. This is the default and just here for
-compatibility with grep. You can also use it for turning B<--no-recurse> off.
+Recur into sub-directories. This is the default and just here for
+compatibility with grep. You can also use it for turning B<--no-recur> off.
 
 =item B<--smart-case>, B<--no-smart-case>
 
@@ -1356,7 +1356,7 @@ sub get_command_line_options {
         'L|files-without-matches' => sub { $opt{l} = $opt{v} = 1 },
         'm|max-count=i'         => \$opt{m},
         'match=s'               => \$opt{regex},
-        'n|no-recurse'          => \$opt{n},
+        'n|no-recur|no-recurse' => \$opt{n},
         o                       => sub { $opt{output} = '$&' },
         'output=s'              => \$opt{output},
         'pager=s'               => \$opt{pager},
@@ -1364,7 +1364,7 @@ sub get_command_line_options {
         'passthru'              => \$opt{passthru},
         'print0'                => \$opt{print0},
         'Q|literal'             => \$opt{Q},
-        'r|R|recurse'           => sub { $opt{n} = 0 },
+        'r|R|recur|recurse'     => sub { $opt{n} = 0 },
         'show-types'            => \$opt{show_types},
         'smart-case!'           => \$opt{smart_case},
         'sort-files'            => \$opt{sort_files},
@@ -1824,8 +1824,10 @@ File inclusion/exclusion:
                         Ignores CVS, .svn and other ignored directories
   -u, --unrestricted    All files and directories searched
   --[no]ignore-dir=name Add/Remove directory from the list of ignored dirs
-  -r, -R, --recurse     Recurse into subdirectories (ack's default behavior)
-  -n, --no-recurse      No descending into subdirectories
+  -r, -R, --recur       Recur into subdirectories (ack's default behavior)
+  -n, --no-recur        No descending into subdirectories
+  --recurse             Same as --recur
+  --no-recurse          Same as --no-recur
   -G REGEX              Only search files that match REGEX
 
   --perl                Include only Perl files.

--- a/etc/ack.bash_completion.sh
+++ b/etc/ack.bash_completion.sh
@@ -79,6 +79,8 @@ _ack() {
     --nopager
     --passthru
     --print0
+    --recur
+    --norecur
     --recurse
     --norecurse
     --rc=


### PR DESCRIPTION
Heya! Hopefully this isn't too pedantic, but it's always been an English Gotcha for me that ack can't handle "[recur](http://www.merriam-webster.com/dictionary/recur)" and only accepts "[recurse](http://www.merriam-webster.com/dictionary/recurse)" as a flag, so this PR adds duplicate flags for `--[no-]recur` and updates documentation to support both.
