### PR TITLE
Files without an extension

### DIFF
--- a/Ack.pm
+++ b/Ack.pm
@@ -381,6 +381,7 @@ i.e. into %mappings, etc.
 
 sub def_types_from_ARGV {
     my @typedef;
+    my $allow_empty_types;
 
     my $parser = Getopt::Long::Parser->new();
         # pass_through   => leave unrecognized command line arguments alone
@@ -389,10 +390,11 @@ sub def_types_from_ARGV {
     $parser->getoptions(
         'type-set=s' => sub { shift; push @typedef, ['c', shift] },
         'type-add=s' => sub { shift; push @typedef, ['a', shift] },
+        'type-allow-empty' => \$allow_empty_types,
     ) or App::Ack::die( 'See ack --help or ack --man for options.' );
 
     for my $td (@typedef) {
-        my ($type, $ext) = split /=/, $td->[1];
+        my ($type, $ext) = split /=/, $td->[1], -1;
 
         if ( $td->[0] eq 'c' ) {
             # type-set
@@ -415,8 +417,11 @@ sub def_types_from_ARGV {
                 unless exists $mappings{$type};
         }
 
-        my @exts = split /,/, $ext;
+        my @exts = length($ext) ? split /,/, $ext, -1 : '';  # split returns undef on empty string
         s/^\.// for @exts;
+
+        # restore old behavior of ignoring empty typedefs unless explicitly asked to do otherwise
+        @exts = grep{ $_ } @exts unless $allow_empty_types;
 
         if ( !exists $mappings{$type} || ref($mappings{$type}) eq 'ARRAY' ) {
             push @{$mappings{$type}}, @exts;
@@ -507,6 +512,10 @@ sub filetypes {
     # If there's an extension, look it up
     if ( $filename =~ m{\.([^\.$dir_sep_chars]+)$}o ) {
         my $ref = $types{lc $1};
+        return (@{$ref},TEXT) if $ref;
+    } elsif ( exists $types{''} ) {
+        # files without extensions could have an user defined type
+        my $ref = $types{''};
         return (@{$ref},TEXT) if $ref;
     }
 
@@ -806,6 +815,8 @@ File inclusion/exclusion:
   --type-add TYPE=.EXTENSION[,.EXT2[,...]]
                         Files with the given EXTENSION(s) are recognized as
                         being of (the existing) type TYPE
+  --type-allow-empty    Allow files without an extension to be recognized as
+                        a distinct type.
 
   --[no]follow          Follow symlinks.  Default is off.
 

--- a/ack
+++ b/ack
@@ -1503,6 +1503,7 @@ sub get_command_line_options {
 
 sub def_types_from_ARGV {
     my @typedef;
+    my $allow_empty_types;
 
     my $parser = Getopt::Long::Parser->new();
         # pass_through   => leave unrecognized command line arguments alone
@@ -1511,10 +1512,11 @@ sub def_types_from_ARGV {
     $parser->getoptions(
         'type-set=s' => sub { shift; push @typedef, ['c', shift] },
         'type-add=s' => sub { shift; push @typedef, ['a', shift] },
+        'type-allow-empty' => \$allow_empty_types,
     ) or App::Ack::die( 'See ack --help or ack --man for options.' );
 
     for my $td (@typedef) {
-        my ($type, $ext) = split /=/, $td->[1];
+        my ($type, $ext) = split /=/, $td->[1], -1;
 
         if ( $td->[0] eq 'c' ) {
             # type-set
@@ -1537,8 +1539,11 @@ sub def_types_from_ARGV {
                 unless exists $mappings{$type};
         }
 
-        my @exts = split /,/, $ext;
+        my @exts = length($ext) ? split /,/, $ext, -1 : '';  # split returns undef on empty string
         s/^\.// for @exts;
+
+        # restore old behavior of ignoring empty typedefs unless explicitly asked to do otherwise
+        @exts = grep{ $_ } @exts unless $allow_empty_types;
 
         if ( !exists $mappings{$type} || ref($mappings{$type}) eq 'ARRAY' ) {
             push @{$mappings{$type}}, @exts;
@@ -1599,6 +1604,10 @@ sub filetypes {
     # If there's an extension, look it up
     if ( $filename =~ m{\.([^\.$dir_sep_chars]+)$}o ) {
         my $ref = $types{lc $1};
+        return (@{$ref},TEXT) if $ref;
+    } elsif ( exists $types{''} ) {
+        # files without extensions could have an user defined type
+        my $ref = $types{''};
         return (@{$ref},TEXT) if $ref;
     }
 
@@ -1848,6 +1857,8 @@ File inclusion/exclusion:
   --type-add TYPE=.EXTENSION[,.EXT2[,...]]
                         Files with the given EXTENSION(s) are recognized as
                         being of (the existing) type TYPE
+  --type-allow-empty    Allow files without an extension to be recognized as
+                        a distinct type.
 
   --[no]follow          Follow symlinks.  Default is off.
 

--- a/t/ack-text.t
+++ b/t/ack-text.t
@@ -48,6 +48,7 @@ ACK_F_TEXT: {
         t/swamp/Makefile
         t/swamp/Makefile.PL
         t/swamp/javascript.js
+        t/swamp/no-extension
         t/swamp/not-an-#emacs-workfile#
         t/swamp/notaMakefile
         t/swamp/notaRakefile

--- a/t/ack-type.t
+++ b/t/ack-type.t
@@ -3,7 +3,7 @@
 use warnings;
 use strict;
 
-use Test::More tests => 74;
+use Test::More tests => 82;
 
 use lib 't';
 use Util qw( sets_match );
@@ -36,6 +36,15 @@ my $foo = [qw(
 my $bar = [qw(
     t/swamp/file.bar
 )];
+
+my $none = [
+    't/swamp/0',
+    't/swamp/no-extension',
+    't/swamp/not-an-#emacs-workfile#',
+    't/swamp/notaMakefile',
+    't/swamp/notaRakefile',
+    't/swamp/perl-without-extension',
+];
 
 my $xml = [qw(
     t/etc/buttonhook.rss.xxx
@@ -108,6 +117,15 @@ check_with( '--type-add xml=.foo,.bar --xml', $foo_bar_xml );
 
 # check that --type-set redefines
 check_with( '--type-set cc=.foo --cc', $foo );
+
+# check --type-set with empty EXT
+check_with( '--type-set empty= --type empty --no-recurse', [] );
+check_with( '--type-set empty= --type empty --no-recurse --type-allow-empty', $none );
+
+# check --type-add with empty EXT
+check_with( '--type-add cc= --cc --no-recurse', $cc_hh );
+check_with( '--type-add cc= --cc --no-recurse --type-allow-empty', [ sort @$cc_hh, @$none ]);
+
 
 # check that builtin types cannot be changed
 BUILTIN: {

--- a/t/swamp/no-extension
+++ b/t/swamp/no-extension
@@ -1,0 +1,1 @@
+nothing to see here, move along


### PR DESCRIPTION
Allow files without an extension to be recognized as a distinct type. Keep old behavior unless --type-allow-empty is explicitly specified to ensure backwards-compatibility. Added tests and help text for this change.
