### PR TITLE
Provide an option to set the re::engine to be used searches

### DIFF
--- a/Ack.pm
+++ b/Ack.pm
@@ -46,6 +46,7 @@ our $is_windows;
 use File::Spec ();
 use File::Glob ':glob';
 use Getopt::Long ();
+use Module::Load ();
 
 BEGIN {
     %ignore_dirs = (
@@ -241,6 +242,7 @@ sub get_command_line_options {
         'passthru'              => \$opt{passthru},
         'print0'                => \$opt{print0},
         'Q|literal'             => \$opt{Q},
+        're-engine=s'           => \$opt{re_engine},
         'r|R|recurse'           => sub { $opt{n} = 0 },
         'show-types'            => \$opt{show_types},
         'smart-case!'           => \$opt{smart_case},
@@ -1051,6 +1053,10 @@ sub search_resource {
     my $nmatches = 0;
 
     $display_filename = undef;
+
+    # Import re::engine::* if option is set:
+    $opt->{re_engine} and Module::Load::load(
+        "re::engine::" . delete($opt->{re_engine}), "import" );
 
     # for --line processing
     my $has_lines = 0;

--- a/Ack.pm
+++ b/Ack.pm
@@ -792,6 +792,7 @@ File inclusion/exclusion:
   -u, --unrestricted    All files and directories searched
   --[no]ignore-dir=name Add/Remove directory from the list of ignored dirs
   -r, -R, --recurse     Recurse into subdirectories (ack's default behavior)
+  --re-engine=name      Use re::engine::* when searching
   -n, --no-recurse      No descending into subdirectories
   -G REGEX              Only search files that match REGEX
 

--- a/ack
+++ b/ack
@@ -408,6 +408,11 @@ Quote all metacharacters in PATTERN, it is treated as a literal.
 This applies only to the PATTERN, not to the regexes given for the B<-g>
 and B<-G> options.
 
+=item B<--re-engine=name>
+
+Use an alternative regular expression engine when searching. Pass the option,
+e.g., "RE2" to load and use L<re::engine::RE2>.
+
 =item B<-r>, B<-R>, B<--recurse>
 
 Recurse into sub-directories. This is the default and just here for


### PR DESCRIPTION
The attached patch adds and documents this option:

``` pod
=item B<--re-engine=name>

Use an alternative regular expression engine when searching. Pass the option,
e.g., "RE2" to load and use L<re::engine::RE2>.
```
