### PR TITLE
Add support for Elixir (--elixir)

### DIFF
--- a/Ack.pm
+++ b/Ack.pm
@@ -85,6 +85,7 @@ BEGIN {
         css         => [qw( css )],
         delphi      => [qw( pas int dfm nfm dof dpk dproj groupproj bdsgroup bdsproj )],
         elisp       => [qw( el )],
+        elixir      => [qw( ex exs )],
         erlang      => [qw( erl hrl )],
         fortran     => [qw( f f77 f90 f95 f03 for ftn fpp )],
         go          => [qw( go )],

--- a/Changes
+++ b/Changes
@@ -7,6 +7,8 @@ NEXT
     [FILE TYPE UPDATES]
     Added .psgi to --perl.
 
+    Added Elixir support (--elixir).
+
 
 1.96        Sun Sep 18 13:33:39 CDT 2011
     [ENHANCEMENTS]

--- a/ack
+++ b/ack
@@ -1238,6 +1238,7 @@ BEGIN {
         css         => [qw( css )],
         delphi      => [qw( pas int dfm nfm dof dpk dproj groupproj bdsgroup bdsproj )],
         elisp       => [qw( el )],
+        elixir      => [qw( ex exs )],
         erlang      => [qw( erl hrl )],
         fortran     => [qw( f f77 f90 f95 f03 for ftn fpp )],
         go          => [qw( go )],

--- a/ack-help-types.txt
+++ b/ack-help-types.txt
@@ -20,6 +20,7 @@ Note that some extensions may appear in multiple types.  For example,
     --[no]css          .css
     --[no]delphi       .pas .int .dfm .nfm .dof .dpk .dproj .groupproj .bdsgroup .bdsproj
     --[no]elisp        .el
+    --[no]elixir       .ex .exs
     --[no]erlang       .erl .hrl
     --[no]fortran      .f .f77 .f90 .f95 .f03 .for .ftn .fpp
     --[no]go           .go


### PR DESCRIPTION
So I did some digging through the source code and saw a couple of commits adding types and followed what was on those commits.

Elixir is a functional language built on top of the Erlang VM. You can get more information on the official website: http://elixir-lang.org/

Well, let me know if I did something wrong and I'll fix it.

Thanks.
