### PR TITLE
Fix Bash completion on Debian/Ubuntu

### DIFF
--- a/etc/ack.bash_completion.sh
+++ b/etc/ack.bash_completion.sh
@@ -15,7 +15,7 @@
 have ack || have ack-grep && {
 
 # please accept my apologies for polluting the environment!
-__ack_types=$(ack-grep --help=types 2>/dev/null || ack --help=types 2>/dev/null | \
+__ack_types=$( (ack-grep --help=types 2>/dev/null || ack --help=types 2>/dev/null) | \
   perl -ne 'print "$1 no$1 " if /^\s+--\[no\](\S+)\s+/' 2>/dev/null)
 
 __ack_typeopts=""


### PR DESCRIPTION
Bash completion wasn't working on systems where the command is installed
as ack-grep, and in some cases sourcing the completion was giving an error
message.

In Shell || has lower precedence than |, so in the line setting
__ack_types only the second alternative, ack, had its help output filtered
through the Perl one-liner that extracts the options; on systems where the
command is called ack-grep (Debian and derivatives such as Ubuntu), the
__ack_types variable had the raw help output assigned.

This obviously made $__ack_types contain all sorts of things that aren't
types, so completing incorrectly.

And with the Bash shell option failglob set it also made loading Bash
completion (probably) yield this error message:

  bash: no match: [OPTION]...

This is because the ack help text (which gets separated on spaces)
contains '[OPTION]...', and the square brackets are shell metacharacters,
trying to match a file in the current directory called O... or P... or
similar -- and most directories don't contain a file with any of those
names.

Fixed by adding parens, so either ack-grep or grep is invoked, then the
output of the chosen alternative filtered through the Perl one-liner.
