### PR TITLE
Add support for dart

### DIFF
--- a/Ack.pm
+++ b/Ack.pm
@@ -83,6 +83,7 @@ BEGIN {
         cpp         => [qw( cpp cc cxx m hpp hh h hxx )],
         csharp      => [qw( cs )],
         css         => [qw( css )],
+        dart        => [qw( dart )],
         delphi      => [qw( pas int dfm nfm dof dpk dproj groupproj bdsgroup bdsproj )],
         elisp       => [qw( el )],
         erlang      => [qw( erl hrl )],

--- a/ack
+++ b/ack
@@ -1236,6 +1236,7 @@ BEGIN {
         cpp         => [qw( cpp cc cxx m hpp hh h hxx )],
         csharp      => [qw( cs )],
         css         => [qw( css )],
+        dart        => [qw( dart )],
         delphi      => [qw( pas int dfm nfm dof dpk dproj groupproj bdsgroup bdsproj )],
         elisp       => [qw( el )],
         erlang      => [qw( erl hrl )],

--- a/ack-help-types.txt
+++ b/ack-help-types.txt
@@ -18,6 +18,7 @@ Note that some extensions may appear in multiple types.  For example,
     --[no]cpp          .cpp .cc .cxx .m .hpp .hh .h .hxx
     --[no]csharp       .cs
     --[no]css          .css
+    --[no]dart         .dart
     --[no]delphi       .pas .int .dfm .nfm .dof .dpk .dproj .groupproj .bdsgroup .bdsproj
     --[no]elisp        .el
     --[no]erlang       .erl .hrl


### PR DESCRIPTION
Hi Andy,

This patch adds support for restricting the search to dart files.  I just searched for "python" and added "dart" where alphabetically appropriate.  Let me know if there's more places that need to be added.  (I'm not sure what's auto-generated and what isn't.)

Dart is: http://www.dartlang.org/, BTW :)

Regards,
--jrockway
