### PR TITLE
add --no-filter option to avoiding entering pipe mode

### DIFF
--- a/Ack.pm
+++ b/Ack.pm
@@ -237,6 +237,7 @@ sub get_command_line_options {
         o                       => sub { $opt{output} = '$&' },
         'output=s'              => \$opt{output},
         'pager=s'               => \$opt{pager},
+        'no-filter'              => \$opt{no_filter},
         'nopager'               => sub { $opt{pager} = undef },
         'passthru'              => \$opt{passthru},
         'print0'                => \$opt{print0},
@@ -869,6 +870,7 @@ File inclusion/exclusion:
 
 Miscellaneous:
   --noenv               Ignore environment variables and ~/.ackrc
+  --no-filter            Do not run in filter mode, despite STDIN being a pipe
   --help                This help
   --man                 Man page
   --version             Display version & copyright
@@ -1641,7 +1643,9 @@ Returns true if ack's input is coming from a pipe.
 =cut
 
 sub input_from_pipe {
-    return $input_from_pipe;
+    my $opt = shift;
+
+    return !$opt->{no_filter} && $input_from_pipe;
 }
 
 

--- a/ack-base
+++ b/ack-base
@@ -55,7 +55,7 @@ sub main {
 
     $| = 1 if $opt->{flush}; # Unbuffer the output if flush mode
 
-    if ( App::Ack::input_from_pipe() ) {
+    if ( App::Ack::input_from_pipe( $opt ) ) {
         # We're going into filter mode
         for ( qw( f g l ) ) {
             $opt->{$_} and App::Ack::die( "Can't use -$_ when acting as a filter." );

--- a/ack-help.txt
+++ b/ack-help.txt
@@ -118,6 +118,7 @@ File inclusion/exclusion:
 
 Miscellaneous:
   --noenv               Ignore environment variables and ~/.ackrc
+  --no-filter           Do not run in filter mode, despite STDIN being a pipe
   --help                This help
   --man                 Man page
   --version             Display version & copyright


### PR DESCRIPTION
ack erroneously goes into filter mode. In my case, it happened when I use ack with gnu parallel.

`cat filelist.txt | parallel -L 7 ack "query"`   

Issue: #158 
