### PR TITLE
Add a type option for JVM-type files (currently jars and class) which get ignored by --nobinary

### DIFF
--- a/Ack.pm
+++ b/Ack.pm
@@ -95,6 +95,7 @@ BEGIN {
         java        => [qw( java properties )],
         js          => [qw( js )],
         jsp         => [qw( jsp jspx jhtm jhtml )],
+        jvm         => [qw( class jar )],
         lisp        => [qw( lisp lsp )],
         lua         => [qw( lua )],
         make        => q{Makefiles (including *.mk and *.mak)},

--- a/ack
+++ b/ack
@@ -1248,6 +1248,7 @@ BEGIN {
         java        => [qw( java properties )],
         js          => [qw( js )],
         jsp         => [qw( jsp jspx jhtm jhtml )],
+        jvm         => [qw( class jar )],
         lisp        => [qw( lisp lsp )],
         lua         => [qw( lua )],
         make        => q{Makefiles (including *.mk and *.mak)},

--- a/ack-help-types.txt
+++ b/ack-help-types.txt
@@ -30,6 +30,7 @@ Note that some extensions may appear in multiple types.  For example,
     --[no]java         .java .properties
     --[no]js           .js
     --[no]jsp          .jsp .jspx .jhtm .jhtml
+    --[no]jvm          .class .jar
     --[no]lisp         .lisp .lsp
     --[no]lua          .lua
     --[no]make         Makefiles (including *.mk and *.mak)


### PR DESCRIPTION
Add a type option for JVM-type files (currently jars and class) which get ignored by --nobinary
